### PR TITLE
Script to monitor and download tasks

### DIFF
--- a/monitor_and_download_tasks.py
+++ b/monitor_and_download_tasks.py
@@ -1,0 +1,37 @@
+"""Monitor the tasks stored in the .json file logged with the API."""
+import os
+import json
+
+import inductiva
+
+PATH_TO_JSON = "/Path/to/task_metadata.json"
+DOWNLOAD_TASKS = True
+
+
+def main():
+    json_lines = []
+    with open(PATH_TO_JSON, "r", encoding="utf-8") as json_file:
+        for line in json_file:
+            json_lines.append(json.loads(line))
+
+    task_counts = {}
+
+    for json_line in json_lines:
+        task_input_dir = json_line["input_dir"]
+        task_id = json_line["task_id"]
+        task = inductiva.tasks.Task(task_id)
+        status = task.get_status()
+        if status not in task_counts:
+            task_counts[status] = 1
+        else:
+            task_counts[status] += 1
+
+        if status == "success" and DOWNLOAD_TASKS:
+            task.download_outputs(
+                output_dir=os.path.join(task_input_dir, "downloaded_outputs"))
+
+    print(task_counts)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Using the `tasks_metadata` files automatically logged by the api this script can monitor the status of the tasks and download their outputs.

Here I made the choice of downloading their outputs to the folder `wind_tunnel_input__TASK_NUMBER`. Even though it is strange to download tasks to a file with `inputs` this has the advantage that we use our file manager to keep the outputs of the task and its inputs together without any extra code. This way, later when post-processing, we can simply look for the `downloaded_outputs` folder inside each task and apply any processing steps that we may want.